### PR TITLE
rails6.0

### DIFF
--- a/lib/r_hapi/connection.rb
+++ b/lib/r_hapi/connection.rb
@@ -90,7 +90,7 @@ module RHapi
             RHapi::ConnectionError.raise_error("#{response.response_code}\n Error is: #{err.inspect}")
           end
         end
-        RHapi::ConnectionError.raise_error(response.header_str) unless response.response_code.to_s =~ /2\d\d/
+        RHapi::ConnectionError.raise_error("#{response.header_str.inspect} #{response.response_code.inspect} #{response.body.inspect}") unless response.response_code.to_s =~ /2\d\d/
         response
       end
       


### PR DESCRIPTION
- Added more info from response to RHapi::CeonnectionError message
- Update json
- Bump gem version
- Update curb
- Bump gem version
- Oops, can't get later than the latest lol
- Pin curb to what appears to be a known good version that works with WebMock - 'You are using Curb 1.0.1. WebMock is known to work with Curb >= 0.7.16, < 0.10, except versions 0.8.7. It may not work with this version.'
- Try a newer curb
- relax json version
